### PR TITLE
feat: upgrade axum to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,12 @@ path = "src/lib.rs"
 casbin = { version = "2.0.9", default-features = false, features = ["incremental", "cached"] }
 tokio = { version = "1.17.0", default-features = false, optional = true }
 async-std = { version = "1.10.0", default-features = false, optional = true }
-axum = "0.5.7"
+axum = "0.7.4"
 futures = "0.3"
 tower = { version = "0.4", features = ["full"] }
-http = "0.2.8"
-http-body = "0.4.5"
+http = "1.0.0"
+http-body = "1.0.0"
+http-body-util = "0.1.0"
 bytes = "1.1.0"
 
 [features]
@@ -32,7 +33,7 @@ runtime-async-std = ["casbin/runtime-async-std", "async-std/std"]
 [dev-dependencies]
 tokio = { version = "1.17.0", features = [ "full" ] }
 async-std = { version = "1.10.0", features = [ "attributes" ] }
-axum-test-helper = "0.1.1"
+axum-test-helpers = "0.7.5"
 
 [profile.release]
 codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@
 
 ## Install
 
-Add it to `Cargo.toml`
+Add dependencies to `Cargo.toml`
 
-```toml
-axum = "0.5.7"
-axum-casbin = "1.0.0"
-tokio = { version = "1.17.0", features = [ "full" ] }
+```bash
+cargo add axum
+cargo add axum-casbin
+cargo add tokio --features full
 ```
 
 ## Requirement

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,5 +1,5 @@
 use axum::{
-    body::{self, BoxBody},
+    body,
     response::Response,
     BoxError,
 };
@@ -8,7 +8,8 @@ use casbin::prelude::{TryIntoAdapter, TryIntoModel};
 use casbin::{CachedEnforcer, CoreApi, Result as CasbinResult};
 use futures::future::BoxFuture;
 use http::{Request, StatusCode};
-use http_body::{Body as HttpBody, Full};
+use http_body::{Body as HttpBody};
+use http_body_util::Full;
 use std::{
     convert::Infallible,
     ops::{Deref, DerefMut},
@@ -93,7 +94,7 @@ where
     ResBody: HttpBody<Data = Bytes> + Send + 'static,
     ResBody::Error: Into<BoxError>,
 {
-    type Response = Response<BoxBody>;
+    type Response = Response;
     type Error = Infallible;
     // `BoxFuture` is a type alias for `Pin<Box<dyn Future + Send + 'a>>`
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
@@ -116,7 +117,7 @@ where
                 None => {
                     return Ok(Response::builder()
                         .status(StatusCode::UNAUTHORIZED)
-                        .body(body::boxed(Full::from("401 Unauthorized")))
+                        .body(body::Body::new(Full::from("401 Unauthorized")))
                         .unwrap());
                 }
             };
@@ -129,20 +130,20 @@ where
                     match lock.enforce_mut(vec![subject, domain, path, action]) {
                         Ok(true) => {
                             drop(lock);
-                            Ok(inner.call(req).await?.map(body::boxed))
+                            Ok(inner.call(req).await?.map(body::Body::new))
                         }
                         Ok(false) => {
                             drop(lock);
                             Ok(Response::builder()
                                 .status(StatusCode::FORBIDDEN)
-                                .body(body::boxed(Full::from("403 Forbidden")))
+                                .body(body::Body::new(Full::from("403 Forbidden")))
                                 .unwrap())
                         }
                         Err(_) => {
                             drop(lock);
                             Ok(Response::builder()
                                 .status(StatusCode::BAD_GATEWAY)
-                                .body(body::boxed(Full::from("502 Bad Gateway")))
+                                .body(body::Body::new(Full::from("502 Bad Gateway")))
                                 .unwrap())
                         }
                     }
@@ -151,20 +152,20 @@ where
                     match lock.enforce_mut(vec![subject, path, action]) {
                         Ok(true) => {
                             drop(lock);
-                            Ok(inner.call(req).await?.map(body::boxed))
+                            Ok(inner.call(req).await?.map(body::Body::new))
                         }
                         Ok(false) => {
                             drop(lock);
                             Ok(Response::builder()
                                 .status(StatusCode::FORBIDDEN)
-                                .body(body::boxed(Full::from("403 Forbidden")))
+                                .body(body::Body::new(Full::from("403 Forbidden")))
                                 .unwrap())
                         }
                         Err(_) => {
                             drop(lock);
                             Ok(Response::builder()
                                 .status(StatusCode::BAD_GATEWAY)
-                                .body(body::boxed(Full::from("502 Bad Gateway")))
+                                .body(body::Body::new(Full::from("502 Bad Gateway")))
                                 .unwrap())
                         }
                     }
@@ -172,7 +173,7 @@ where
             } else {
                 Ok(Response::builder()
                     .status(StatusCode::UNAUTHORIZED)
-                    .body(body::boxed(Full::from("401 Unauthorized")))
+                    .body(body::Body::new(Full::from("401 Unauthorized")))
                     .unwrap())
             }
         })

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,14 +1,10 @@
-use axum::{
-    body,
-    response::Response,
-    BoxError,
-};
+use axum::{body, response::Response, BoxError};
 use bytes::Bytes;
 use casbin::prelude::{TryIntoAdapter, TryIntoModel};
 use casbin::{CachedEnforcer, CoreApi, Result as CasbinResult};
 use futures::future::BoxFuture;
 use http::{Request, StatusCode};
-use http_body::{Body as HttpBody};
+use http_body::Body as HttpBody;
 use http_body_util::Full;
 use std::{
     convert::Infallible,

--- a/tests/test_middleware.rs
+++ b/tests/test_middleware.rs
@@ -1,6 +1,6 @@
 use axum::{response::Response, routing::get, BoxError, Router};
 use axum_casbin::{CasbinAxumLayer, CasbinVals};
-use axum_test_helper::TestClient;
+use axum_test_helpers::TestClient;
 use bytes::Bytes;
 use casbin::function_map::key_match2;
 use casbin::{CoreApi, DefaultModel, FileAdapter};
@@ -95,12 +95,12 @@ async fn test_middleware() {
 
     let client = TestClient::new(app);
 
-    let resp_pen_1 = client.get("/pen/1").send().await;
+    let resp_pen_1 = client.get("/pen/1").await;
     assert_eq!(resp_pen_1.status(), StatusCode::OK);
 
-    let resp_book = client.get("/book/2").send().await;
+    let resp_book = client.get("/book/2").await;
     assert_eq!(resp_book.status(), StatusCode::OK);
 
-    let resp_pen_2 = client.get("/pen/2").send().await;
+    let resp_pen_2 = client.get("/pen/2").await;
     assert_eq!(resp_pen_2.status(), StatusCode::FORBIDDEN);
 }

--- a/tests/test_middleware_domain.rs
+++ b/tests/test_middleware_domain.rs
@@ -1,6 +1,6 @@
 use axum::{response::Response, routing::get, BoxError, Router};
 use axum_casbin::{CasbinAxumLayer, CasbinVals};
-use axum_test_helper::TestClient;
+use axum_test_helpers::TestClient;
 use bytes::Bytes;
 use casbin::{DefaultModel, FileAdapter};
 use futures::future::BoxFuture;
@@ -85,9 +85,9 @@ async fn test_middleware_domain() {
 
     let client = TestClient::new(app);
 
-    let resp_pen = client.get("/pen/1").send().await;
+    let resp_pen = client.get("/pen/1").await;
     assert_eq!(resp_pen.status(), StatusCode::OK);
 
-    let resp_book = client.get("/book/1").send().await;
+    let resp_book = client.get("/book/1").await;
     assert_eq!(resp_book.status(), StatusCode::FORBIDDEN);
 }

--- a/tests/test_set_enforcer.rs
+++ b/tests/test_set_enforcer.rs
@@ -1,6 +1,6 @@
 use axum::{response::Response, routing::get, BoxError, Router};
 use axum_casbin::{CasbinAxumLayer, CasbinVals};
-use axum_test_helper::TestClient;
+use axum_test_helpers::TestClient;
 use bytes::Bytes;
 use casbin::function_map::key_match2;
 use casbin::{CachedEnforcer, CoreApi, DefaultModel, FileAdapter};
@@ -103,12 +103,12 @@ async fn test_set_enforcer() {
 
     let client = TestClient::new(app);
 
-    let resp_pen_1 = client.get("/pen/1").send().await;
+    let resp_pen_1 = client.get("/pen/1").await;
     assert_eq!(resp_pen_1.status(), StatusCode::OK);
 
-    let resp_book = client.get("/book/2").send().await;
+    let resp_book = client.get("/book/2").await;
     assert_eq!(resp_book.status(), StatusCode::OK);
 
-    let resp_pen_2 = client.get("/pen/2").send().await;
+    let resp_pen_2 = client.get("/pen/2").await;
     assert_eq!(resp_pen_2.status(), StatusCode::FORBIDDEN);
 }


### PR DESCRIPTION
Fix #7 

- Upgrade axum to 0.7
- Other dependency upgrades are required by axum 0.7
- `axum-test-helper` doesn't support axum 0.7 right now, switched to `axum-test-helpers`
- Update README.md

Refer

- https://github.com/tokio-rs/axum/releases/tag/axum-v0.7.0
- https://github.com/hyperium/http-body/blob/master/http-body/CHANGELOG.md