### PR TITLE
feat: Update dependencies which require switch to axum-test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,16 +13,16 @@ name = "axum_casbin"
 path = "src/lib.rs"
 
 [dependencies]
-casbin = { version = "2.0.9", default-features = false, features = ["incremental", "cached"] }
-tokio = { version = "1.17.0", default-features = false, optional = true }
-async-std = { version = "1.10.0", default-features = false, optional = true }
-axum = "0.7.4"
+casbin = { version = "2.10.1", default-features = false, features = ["incremental", "cached"] }
+tokio = { version = "1.43.0", default-features = false, optional = true }
+async-std = { version = "1.13.0", default-features = false, optional = true }
+axum = "0.8.1"
 futures = "0.3"
-tower = { version = "0.4", features = ["full"] }
-http = "1.0.0"
-http-body = "1.0.0"
-http-body-util = "0.1.0"
-bytes = "1.1.0"
+tower = { version = "0.5", features = ["full"] }
+http = "1.2.0"
+http-body = "1.0.1"
+http-body-util = "0.1.2"
+bytes = "1.8"
 
 [features]
 default = ["runtime-tokio"]
@@ -31,9 +31,9 @@ runtime-tokio = ["casbin/runtime-tokio", "tokio/sync"]
 runtime-async-std = ["casbin/runtime-async-std", "async-std/std"]
 
 [dev-dependencies]
-tokio = { version = "1.17.0", features = [ "full" ] }
-async-std = { version = "1.10.0", features = [ "attributes" ] }
-axum-test-helpers = "0.7.5"
+tokio = { version = "1.43.0", features = [ "full" ] }
+async-std = { version = "1.13.0", features = [ "attributes" ] }
+axum-test = "17.2.0"
 
 [profile.release]
 codegen-units = 1

--- a/tests/test_middleware.rs
+++ b/tests/test_middleware.rs
@@ -1,6 +1,6 @@
 use axum::{response::Response, routing::get, BoxError, Router};
 use axum_casbin::{CasbinAxumLayer, CasbinVals};
-use axum_test_helpers::TestClient;
+use axum_test::TestServer;
 use bytes::Bytes;
 use casbin::function_map::key_match2;
 use casbin::{CoreApi, DefaultModel, FileAdapter};
@@ -89,18 +89,18 @@ async fn test_middleware() {
     let app = Router::new()
         .route("/pen/1", get(handler))
         .route("/pen/2", get(handler))
-        .route("/book/:id", get(handler))
+        .route("/book/{id}", get(handler))
         .layer(casbin_middleware)
         .layer(FakeAuthLayer);
 
-    let client = TestClient::new(app);
+    let client = TestServer::new(app).unwrap();
 
     let resp_pen_1 = client.get("/pen/1").await;
-    assert_eq!(resp_pen_1.status(), StatusCode::OK);
+    assert_eq!(resp_pen_1.status_code(), StatusCode::OK);
 
     let resp_book = client.get("/book/2").await;
-    assert_eq!(resp_book.status(), StatusCode::OK);
+    assert_eq!(resp_book.status_code(), StatusCode::OK);
 
     let resp_pen_2 = client.get("/pen/2").await;
-    assert_eq!(resp_pen_2.status(), StatusCode::FORBIDDEN);
+    assert_eq!(resp_pen_2.status_code(), StatusCode::FORBIDDEN);
 }

--- a/tests/test_middleware_domain.rs
+++ b/tests/test_middleware_domain.rs
@@ -1,6 +1,6 @@
 use axum::{response::Response, routing::get, BoxError, Router};
 use axum_casbin::{CasbinAxumLayer, CasbinVals};
-use axum_test_helpers::TestClient;
+use axum_test::TestServer;
 use bytes::Bytes;
 use casbin::{DefaultModel, FileAdapter};
 use futures::future::BoxFuture;
@@ -83,11 +83,11 @@ async fn test_middleware_domain() {
         .layer(casbin_middleware)
         .layer(FakeAuthLayer);
 
-    let client = TestClient::new(app);
+    let client = TestServer::new(app).unwrap();
 
     let resp_pen = client.get("/pen/1").await;
-    assert_eq!(resp_pen.status(), StatusCode::OK);
+    assert_eq!(resp_pen.status_code(), StatusCode::OK);
 
     let resp_book = client.get("/book/1").await;
-    assert_eq!(resp_book.status(), StatusCode::FORBIDDEN);
+    assert_eq!(resp_book.status_code(), StatusCode::FORBIDDEN);
 }

--- a/tests/test_set_enforcer.rs
+++ b/tests/test_set_enforcer.rs
@@ -1,6 +1,6 @@
 use axum::{response::Response, routing::get, BoxError, Router};
 use axum_casbin::{CasbinAxumLayer, CasbinVals};
-use axum_test_helpers::TestClient;
+use axum_test::TestServer;
 use bytes::Bytes;
 use casbin::function_map::key_match2;
 use casbin::{CachedEnforcer, CoreApi, DefaultModel, FileAdapter};
@@ -97,18 +97,18 @@ async fn test_set_enforcer() {
     let app = Router::new()
         .route("/pen/1", get(handler))
         .route("/pen/2", get(handler))
-        .route("/book/:id", get(handler))
+        .route("/book/{id}", get(handler))
         .layer(casbin_middleware)
         .layer(FakeAuthLayer);
 
-    let client = TestClient::new(app);
+    let client = TestServer::new(app).unwrap();
 
     let resp_pen_1 = client.get("/pen/1").await;
-    assert_eq!(resp_pen_1.status(), StatusCode::OK);
+    assert_eq!(resp_pen_1.status_code(), StatusCode::OK);
 
     let resp_book = client.get("/book/2").await;
-    assert_eq!(resp_book.status(), StatusCode::OK);
+    assert_eq!(resp_book.status_code(), StatusCode::OK);
 
     let resp_pen_2 = client.get("/pen/2").await;
-    assert_eq!(resp_pen_2.status(), StatusCode::FORBIDDEN);
+    assert_eq!(resp_pen_2.status_code(), StatusCode::FORBIDDEN);
 }


### PR DESCRIPTION
Switch to axum-test as axum-test-helpers doesn't seem to be compatible with latest axum. Also axum-test seems to be much more activly maintained.