### PR TITLE
feat: do refactoring, simplify middleware & tests implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,7 @@ casbin = { version = "2.10.1", default-features = false, features = ["incrementa
 tokio = { version = "1.43.0", default-features = false, optional = true }
 async-std = { version = "1.13.0", default-features = false, optional = true }
 axum = "0.8.1"
-futures = "0.3"
-tower = { version = "0.5", features = ["full"] }
-http = "1.2.0"
-http-body = "1.0.1"
-http-body-util = "0.1.2"
-bytes = "1.8"
+tower = { version = "0.5" }
 
 [features]
 default = ["runtime-tokio"]

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -130,7 +130,7 @@ where
             match result {
                 Ok(true) => Ok(future.await?),
                 Ok(false) => ok(StatusCode::FORBIDDEN),
-                Err(_) => ok(StatusCode::BAD_GATEWAY),
+                Err(_) => ok(StatusCode::INTERNAL_SERVER_ERROR),
             }
         })
     }

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,13 +1,12 @@
-use axum::{body, response::Response, BoxError};
-use bytes::Bytes;
+use axum::extract::Request;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::response::Response;
 use casbin::prelude::{TryIntoAdapter, TryIntoModel};
 use casbin::{CachedEnforcer, CoreApi, Result as CasbinResult};
-use futures::future::BoxFuture;
-use http::{Request, StatusCode};
-use http_body::Body as HttpBody;
-use http_body_util::Full;
+use std::future::Future;
+use std::pin::Pin;
 use std::{
-    convert::Infallible,
     ops::{Deref, DerefMut},
     sync::Arc,
     task::{Context, Poll},
@@ -78,81 +77,60 @@ pub struct CasbinAxumMiddleware<S> {
     enforcer: Arc<RwLock<CachedEnforcer>>,
 }
 
-impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for CasbinAxumMiddleware<S>
+impl<S> Service<Request> for CasbinAxumMiddleware<S>
 where
-    S: Service<Request<ReqBody>, Response = Response<ResBody>, Error = Infallible>
-        + Clone
-        + Send
-        + 'static,
+    S: Service<Request, Response = Response> + Send + 'static,
     S::Future: Send + 'static,
-    ReqBody: Send + 'static,
-    Infallible: From<<S as Service<Request<ReqBody>>>::Error>,
-    ResBody: HttpBody<Data = Bytes> + Send + 'static,
-    ResBody::Error: Into<BoxError>,
 {
     type Response = Response;
-    type Error = Infallible;
-    // `BoxFuture` is a type alias for `Pin<Box<dyn Future + Send + 'a>>`
-    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+    type Error = S::Error;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.inner.poll_ready(cx)
     }
 
-    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+    fn call(&mut self, req: Request) -> Self::Future {
         let cloned_enforcer = self.enforcer.clone();
-        let not_ready_inner = self.inner.clone();
-        let mut inner = std::mem::replace(&mut self.inner, not_ready_inner);
+        let path = req.uri().path().to_string();
+        let action = req.method().as_str().to_string();
+        let option_vals = req.extensions().get::<CasbinVals>().cloned();
+        let future = self.inner.call(req);
 
         Box::pin(async move {
-            let path = req.uri().path().to_string();
-            let action = req.method().as_str().to_string();
-            let option_vals = req.extensions().get::<CasbinVals>().map(|x| x.to_owned());
+            fn ok<E>(s: StatusCode) -> Result<Response, E> {
+                Ok(s.into_response())
+            }
+
             let vals = match option_vals {
                 Some(value) => value,
                 None => {
-                    return Ok(Response::builder()
-                        .status(StatusCode::UNAUTHORIZED)
-                        .body(body::Body::new(Full::from("401 Unauthorized")))
-                        .unwrap());
+                    return ok(StatusCode::UNAUTHORIZED);
                 }
             };
 
             let subject = vals.subject;
 
-            if !subject.is_empty() {
-                let mut lock = cloned_enforcer.write().await;
-                let args = if let Some(domain) = vals.domain {
-                    vec![subject, domain, path, action]
-                } else {
-                    vec![subject, path, action]
-                };
+            if subject.is_empty() {
+                return ok(StatusCode::UNAUTHORIZED);
+            }
 
-                match lock.enforce_mut(args) {
-                    Ok(true) => {
-                        drop(lock);
-                        Ok(inner.call(req).await?.map(body::Body::new))
-                    }
-                    Ok(false) => {
-                        drop(lock);
-                        Ok(Response::builder()
-                            .status(StatusCode::FORBIDDEN)
-                            .body(body::Body::new(Full::from("403 Forbidden")))
-                            .unwrap())
-                    }
-                    Err(_) => {
-                        drop(lock);
-                        Ok(Response::builder()
-                            .status(StatusCode::BAD_GATEWAY)
-                            .body(body::Body::new(Full::from("502 Bad Gateway")))
-                            .unwrap())
-                    }
-                }
+            let args = if let Some(domain) = vals.domain {
+                vec![subject, domain, path, action]
             } else {
-                Ok(Response::builder()
-                    .status(StatusCode::UNAUTHORIZED)
-                    .body(body::Body::new(Full::from("401 Unauthorized")))
-                    .unwrap())
+                vec![subject, path, action]
+            };
+
+            let result = {
+                let mut guard = cloned_enforcer.write().await;
+                guard.enforce_mut(args)
+            };
+
+            match result {
+                Ok(true) => Ok(future.await?),
+                Ok(false) => ok(StatusCode::FORBIDDEN),
+                Err(_) => ok(StatusCode::BAD_GATEWAY),
             }
         })
     }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,0 +1,40 @@
+use axum::extract::Request;
+use std::task::{Context, Poll};
+use tower::{Layer, Service};
+
+pub use axum::{http::StatusCode, routing::get, Router};
+pub use axum_casbin::{CasbinAxumLayer, CasbinVals};
+pub use axum_test::TestServer;
+pub use casbin::{CoreApi, DefaultModel, FileAdapter};
+
+pub async fn handler() {}
+
+#[derive(Clone)]
+pub struct TestAuthLayer(pub CasbinVals);
+
+impl<S> Layer<S> for TestAuthLayer {
+    type Service = TestAuthMiddleware<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        TestAuthMiddleware(inner, self.0.clone())
+    }
+}
+
+#[derive(Clone)]
+pub struct TestAuthMiddleware<S>(S, CasbinVals);
+
+impl<S> Service<Request> for TestAuthMiddleware<S>
+where
+    S: Service<Request>,
+{
+    type Error = S::Error;
+    type Future = S::Future;
+    type Response = S::Response;
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.0.poll_ready(cx)
+    }
+    fn call(&mut self, mut req: Request) -> Self::Future {
+        req.extensions_mut().insert(self.1.clone());
+        self.0.call(req)
+    }
+}

--- a/tests/test_middleware.rs
+++ b/tests/test_middleware.rs
@@ -1,72 +1,7 @@
-use axum::{response::Response, routing::get, BoxError, Router};
-use axum_casbin::{CasbinAxumLayer, CasbinVals};
-use axum_test::TestServer;
-use bytes::Bytes;
+use common::*;
+mod common;
+
 use casbin::function_map::key_match2;
-use casbin::{CoreApi, DefaultModel, FileAdapter};
-use futures::future::BoxFuture;
-use http::{Request, StatusCode};
-use http_body::Body as HttpBody;
-use std::{
-    convert::Infallible,
-    task::{Context, Poll},
-};
-use tower::{Layer, Service};
-
-#[derive(Clone)]
-struct FakeAuthLayer;
-
-impl<S> Layer<S> for FakeAuthLayer {
-    type Service = FakeAuthMiddleware<S>;
-
-    fn layer(&self, inner: S) -> Self::Service {
-        FakeAuthMiddleware { inner }
-    }
-}
-
-#[derive(Clone)]
-struct FakeAuthMiddleware<S> {
-    inner: S,
-}
-
-impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for FakeAuthMiddleware<S>
-where
-    S: Service<Request<ReqBody>, Response = Response<ResBody>, Error = Infallible>
-        + Clone
-        + Send
-        + 'static,
-    S::Future: Send + 'static,
-    ReqBody: Send + 'static,
-    Infallible: From<<S as Service<Request<ReqBody>>>::Error>,
-    ResBody: HttpBody<Data = Bytes> + Send + 'static,
-    ResBody::Error: Into<BoxError>,
-{
-    type Response = S::Response;
-    type Error = S::Error;
-    // `BoxFuture` is a type alias for `Pin<Box<dyn Future + Send + 'a>>`
-    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
-
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx)
-    }
-
-    fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
-        let not_ready_inner = self.inner.clone();
-        let mut inner = std::mem::replace(&mut self.inner, not_ready_inner);
-
-        Box::pin(async move {
-            let vals = CasbinVals {
-                subject: String::from("alice"),
-                domain: None,
-            };
-            req.extensions_mut().insert(vals);
-            inner.call(req).await
-        })
-    }
-}
-
-// Handler that immediately returns an empty `200 OK` response.
-async fn handler() {}
 
 #[cfg_attr(feature = "runtime-tokio", tokio::test)]
 #[cfg_attr(feature = "runtime-async-std", async_std::test)]
@@ -91,7 +26,10 @@ async fn test_middleware() {
         .route("/pen/2", get(handler))
         .route("/book/{id}", get(handler))
         .layer(casbin_middleware)
-        .layer(FakeAuthLayer);
+        .layer(TestAuthLayer(CasbinVals {
+            subject: String::from("alice"),
+            domain: None,
+        }));
 
     let client = TestServer::new(app).unwrap();
 

--- a/tests/test_middleware_domain.rs
+++ b/tests/test_middleware_domain.rs
@@ -1,71 +1,5 @@
-use axum::{response::Response, routing::get, BoxError, Router};
-use axum_casbin::{CasbinAxumLayer, CasbinVals};
-use axum_test::TestServer;
-use bytes::Bytes;
-use casbin::{DefaultModel, FileAdapter};
-use futures::future::BoxFuture;
-use http::{Request, StatusCode};
-use http_body::Body as HttpBody;
-use std::{
-    convert::Infallible,
-    task::{Context, Poll},
-};
-use tower::{Layer, Service};
-
-#[derive(Clone)]
-struct FakeAuthLayer;
-
-impl<S> Layer<S> for FakeAuthLayer {
-    type Service = FakeAuthMiddleware<S>;
-
-    fn layer(&self, inner: S) -> Self::Service {
-        FakeAuthMiddleware { inner }
-    }
-}
-
-#[derive(Clone)]
-struct FakeAuthMiddleware<S> {
-    inner: S,
-}
-
-impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for FakeAuthMiddleware<S>
-where
-    S: Service<Request<ReqBody>, Response = Response<ResBody>, Error = Infallible>
-        + Clone
-        + Send
-        + 'static,
-    S::Future: Send + 'static,
-    ReqBody: Send + 'static,
-    Infallible: From<<S as Service<Request<ReqBody>>>::Error>,
-    ResBody: HttpBody<Data = Bytes> + Send + 'static,
-    ResBody::Error: Into<BoxError>,
-{
-    type Response = S::Response;
-    type Error = S::Error;
-    // `BoxFuture` is a type alias for `Pin<Box<dyn Future + Send + 'a>>`
-    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
-
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx)
-    }
-
-    fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
-        let not_ready_inner = self.inner.clone();
-        let mut inner = std::mem::replace(&mut self.inner, not_ready_inner);
-
-        Box::pin(async move {
-            let vals = CasbinVals {
-                subject: String::from("alice"),
-                domain: Option::from(String::from("domain1")),
-            };
-            req.extensions_mut().insert(vals);
-            inner.call(req).await
-        })
-    }
-}
-
-// Handler that immediately returns an empty `200 OK` response.
-async fn handler() {}
+use common::*;
+mod common;
 
 #[cfg_attr(feature = "runtime-tokio", tokio::test)]
 #[cfg_attr(feature = "runtime-async-std", async_std::test)]
@@ -81,7 +15,10 @@ async fn test_middleware_domain() {
         .route("/pen/1", get(handler))
         .route("/book/1", get(handler))
         .layer(casbin_middleware)
-        .layer(FakeAuthLayer);
+        .layer(TestAuthLayer(CasbinVals {
+            subject: "alice".into(),
+            domain: Some("domain1".into()),
+        }));
 
     let client = TestServer::new(app).unwrap();
 

--- a/tests/test_set_enforcer.rs
+++ b/tests/test_set_enforcer.rs
@@ -1,79 +1,15 @@
-use axum::{response::Response, routing::get, BoxError, Router};
-use axum_casbin::{CasbinAxumLayer, CasbinVals};
-use axum_test::TestServer;
-use bytes::Bytes;
+use common::*;
+mod common;
+
 use casbin::function_map::key_match2;
-use casbin::{CachedEnforcer, CoreApi, DefaultModel, FileAdapter};
-use futures::future::BoxFuture;
-use http::{Request, StatusCode};
-use http_body::Body as HttpBody;
-use std::{
-    convert::Infallible,
-    sync::Arc,
-    task::{Context, Poll},
-};
-use tower::{Layer, Service};
+use casbin::CachedEnforcer;
+use std::sync::Arc;
 
 #[cfg(feature = "runtime-tokio")]
 use tokio::sync::RwLock;
 
 #[cfg(feature = "runtime-async-std")]
 use async_std::sync::RwLock;
-
-#[derive(Clone)]
-struct FakeAuthLayer;
-
-impl<S> Layer<S> for FakeAuthLayer {
-    type Service = FakeAuthMiddleware<S>;
-
-    fn layer(&self, inner: S) -> Self::Service {
-        FakeAuthMiddleware { inner }
-    }
-}
-
-#[derive(Clone)]
-struct FakeAuthMiddleware<S> {
-    inner: S,
-}
-
-impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for FakeAuthMiddleware<S>
-where
-    S: Service<Request<ReqBody>, Response = Response<ResBody>, Error = Infallible>
-        + Clone
-        + Send
-        + 'static,
-    S::Future: Send + 'static,
-    ReqBody: Send + 'static,
-    Infallible: From<<S as Service<Request<ReqBody>>>::Error>,
-    ResBody: HttpBody<Data = Bytes> + Send + 'static,
-    ResBody::Error: Into<BoxError>,
-{
-    type Response = S::Response;
-    type Error = S::Error;
-    // `BoxFuture` is a type alias for `Pin<Box<dyn Future + Send + 'a>>`
-    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
-
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx)
-    }
-
-    fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
-        let not_ready_inner = self.inner.clone();
-        let mut inner = std::mem::replace(&mut self.inner, not_ready_inner);
-
-        Box::pin(async move {
-            let vals = CasbinVals {
-                subject: String::from("alice"),
-                domain: None,
-            };
-            req.extensions_mut().insert(vals);
-            inner.call(req).await
-        })
-    }
-}
-
-// Handler that immediately returns an empty `200 OK` response.
-async fn handler() {}
 
 #[cfg_attr(feature = "runtime-tokio", tokio::test)]
 #[cfg_attr(feature = "runtime-async-std", async_std::test)]
@@ -99,7 +35,10 @@ async fn test_set_enforcer() {
         .route("/pen/2", get(handler))
         .route("/book/{id}", get(handler))
         .layer(casbin_middleware)
-        .layer(FakeAuthLayer);
+        .layer(TestAuthLayer(CasbinVals {
+            subject: String::from("alice"),
+            domain: None,
+        }));
 
     let client = TestServer::new(app).unwrap();
 


### PR DESCRIPTION
This PR refactors and simplifies the implementation of the Casbin Axum middleware with the following improvements:

 - Streamlined the middleware Service implementation
 - Deduplicated TestMiddleware implementations
 - Updated the example code in the README (since the previous example did not support axum 0.8).
 - Changing the error status code from [BAD_GATEWAY](https://datatracker.ietf.org/doc/html/rfc9110#section-15.6.3) to  a more appropriate [INTERNAL_SERVER_ERROR](https://datatracker.ietf.org/doc/html/rfc9110#section-15.6.1), enhancing semantic accuracy.
 
https://docs.rs/axum/latest/axum/middleware/index.html#towerservice-and-pinboxdyn-future
https://docs.rs/axum/latest/axum/middleware/index.html#accessing-state-in-custom-towerlayers
https://github.com/tower-rs/tower/blob/master/guides/building-a-middleware-from-scratch.md?plain=1#L58-L59